### PR TITLE
Hide more Twitter embeds during VRT

### DIFF
--- a/lostpixel.config.ts
+++ b/lostpixel.config.ts
@@ -12,7 +12,7 @@ async function hide3rdPartyEmbeds(page: Page) {
   await page.addStyleTag({
     content: `
         .embed iframe,
-        .twitter-tweet iframe {
+        .twitter-tweet-rendered {
           display: none !important;
         }
       `,


### PR DESCRIPTION
Fixes more flaky tests. Twitter's iframe may not appear in time for shifting to still occur.

This change means an inconsistency in showing tweets during VRT, in the name of a consistent test suite.

* Tweets that are no longer accessible remain visible as blockquotes during VRT.
* Tweets that still load will be completely invisible during VRT.