### PR TITLE
Opt "About Me" into typography styles piecemeal

### DIFF
--- a/src/components/layouts/page.astro
+++ b/src/components/layouts/page.astro
@@ -10,6 +10,6 @@ const { frontmatter } = Astro.props
       <h2>{frontmatter.title}</h2>
     </header>
 
-    <div class='post'><slot /></div>
+    <slot />
   </article>
 </Layout>

--- a/src/components/resume/experience.astro
+++ b/src/components/resume/experience.astro
@@ -7,32 +7,23 @@ interface Props {
   position: string
 }
 
-const undoInheritedGlobalParagraphStyle = {
-  margin: 0,
-}
-
 const props: Props = Astro.props
 ---
 
 <div class={`border-l-4 border-gray-300 px-4 text-xs ${props.className || ''}`}>
-  <h5
+  <h3
     class='grid grid-flow-col grid-cols-[auto_auto] grid-rows-[1fr_0.5fr] items-center justify-between gap-x-4'
   >
-    <p class='text-lg font-bold' style={undoInheritedGlobalParagraphStyle}>
-      {props.company}
-    </p>
+    <p class='font-bold text-lg'>{props.company}</p>
 
-    <p style={undoInheritedGlobalParagraphStyle}>{props.position}</p>
+    <p class="italic">{props.position}</p>
 
-    <p
-      class="justify-self-end space-x-1"
-      style={undoInheritedGlobalParagraphStyle}
-    >
+    <p class="justify-self-end space-x-1">
       <slot name="time"></slot>
     </p>
 
     <address class='justify-self-end'>{props.location}</address>
-  </h5>
+  </h3>
 
-  <div class='text-justify'><slot /></div>
+  <div class='mt-1 text-justify'><slot /></div>
 </div>

--- a/src/components/resume/experiences.astro
+++ b/src/components/resume/experiences.astro
@@ -1,0 +1,140 @@
+---
+import Experience from './experience.astro'
+import Time from './time.astro'
+---
+
+<Experience
+  className='mt-4'
+  company='Self'
+  location='Remote, Portland, OR'
+  position='Software Development Consultant'
+>
+  <Time begin={new Date('2020-07-15')} end='present' slot='time' />
+
+  <ul class='list-disc ml-4'>
+    <li>
+      Prototyped and adopted tooling, component libraries, test coverage,
+      and code review guidelines, for clients such as WhoCo and Media Arts
+      Lab (Apple), using React, Ember.js, and Python.
+    </li>
+    <li>
+      Maintained OSS libraries:
+      <ul class='list-disc ml-6'>
+        <li>
+          <a
+            class='link'
+            href='https://github.com/john-kurkowski/tldextract'
+          >
+            tldextract
+          </a>{' '}
+          Python library to parse URLs (35k+ dependents).
+        </li>
+        <li>
+          <a
+            class='link'
+            href='https://github.com/john-kurkowski/music'
+          >
+            music
+          </a>{' '}
+          Python CLI to publish my music (100+ hours error-prone clicks
+          saved).
+        </li>
+      </ul>
+    </li>
+  </ul>
+</Experience>
+
+<Experience
+  className='mt-8'
+  company='CrowdStrike'
+  location='Remote, Portland, OR'
+  position='Senior Software Developer'
+>
+  <Time
+    begin={new Date('2013-04-15')}
+    end={new Date('2020-02-15')}
+    slot='time'
+  />
+
+  <ul class='list-disc ml-4'>
+    <li>
+      Led UX team tech, architecting Ember.js SPAs to triage and hunt
+      advanced security threats.
+    </li>
+    <li>
+      Drove adoption of cross-team component library and microservice
+      Swagger/OpenAPI spec, coordinating Node.js, Python, Scala, and
+      Elasticsearch backends, in AWS.
+    </li>
+    <li>
+      Increased deploys from 1x/month to 10x/day, championing efficiency
+      and team feedback loop.
+    </li>
+    <li>Grew team from 10 customers to 1k+, from 2 developers to 20.</li>
+    <li>
+      Cultivated quality culture: oversaw peer code review, checklists,
+      and automated tests.
+    </li>
+  </ul>
+</Experience>
+
+<Experience
+  className='mt-8'
+  company='Gravity'
+  location='Santa Monica, CA'
+  position='Senior Software Developer'
+>
+  <Time
+    begin={new Date('2010-11-15')}
+    end={new Date('2013-04-15')}
+    slot='time'
+  />
+
+  <ul class='list-disc ml-4'>
+    <li>
+      Developed a Scala platform and 3rd party JavaScript for 30k/hr
+      realtime, personalized article recommendations, embedded in top 200
+      U.S. publisher sites, such as TechCrunch.
+    </li>
+    <li>
+      Ingested 10k/hr live tweets for interest analytics visualizations,
+      showcasing our tech during sales.
+    </li>
+    <li>
+      Built browser extension for staff to annotate 100M node HBase, neo4j
+      ontology.
+    </li>
+    <li>
+      Organized monthly 15-person Scala meetups, fostering local dev
+      community and recruitment.
+    </li>
+  </ul>
+</Experience>
+
+<Experience
+  className='mt-8'
+  company='Quantcast'
+  location='San Francisco, CA'
+  position='Software Developer'
+>
+  <Time
+    begin={new Date('2008-09-15')}
+    end={new Date('2010-08-15')}
+    slot='time'
+  />
+
+  <ul class='list-disc ml-4'>
+    <li>
+      Enhanced Java, MySQL, PostgreSQL audience analytics web app reaching
+      2M+ monthly users.
+    </li>
+    <li>
+      Reported churn risks to CEO in daily Hadoop dashboard, retaining
+      100s of critical customers.
+    </li>
+    <li>
+      Spearheaded modern dev practices: prefix search, Python/Django
+      tooling, DVCS workflows.
+    </li>
+  </ul>
+</Experience>

--- a/src/components/resume/experiences.astro
+++ b/src/components/resume/experiences.astro
@@ -24,18 +24,14 @@ import Time from './time.astro'
           <a
             class='link'
             href='https://github.com/john-kurkowski/tldextract'
-          >
-            tldextract
-          </a>{' '}
+          >tldextract</a>
           Python library to parse URLs (35k+ dependents).
         </li>
         <li>
           <a
             class='link'
             href='https://github.com/john-kurkowski/music'
-          >
-            music
-          </a>{' '}
+          >music</a>
           Python CLI to publish my music (100+ hours error-prone clicks
           saved).
         </li>

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -8,10 +8,6 @@ html {
   }
 }
 
-p + p {
-  @apply mt-4;
-}
-
 .link,
 .post a {
   @apply border-b;

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -6,6 +6,8 @@ title: 'About Me'
 import Experience from '../components/resume/experience.astro'
 import Time from '../components/resume/time.astro'
 
+<div class="post">
+
 I’m a full stack web developer, frontend-leaning. I’m obsessed with UX, DX, and
 raising team capability. With 14+ years in the game, I specialize in the
 following.
@@ -52,6 +54,8 @@ following.
 
 ## Experience
 
+</div>
+
 <Experience className='mt-4' company='Self' location='Remote, Portland, OR'
 position='Software Development Consultant'
 
@@ -59,14 +63,33 @@ position='Software Development Consultant'
 
 <Time begin={new Date('2020-07-15')} end='present' slot='time' />
 
-- Prototyped and adopted tooling, component libraries, test coverage, and code
-  review guidelines, for clients such as WhoCo and Media Arts Lab (Apple), using
-  React, Ember.js, and Python.
-- Maintained OSS libraries:
-  - [tldextract](https://github.com/john-kurkowski/tldextract) Python library to
-    parse URLs (35k+ dependents).
-  - [music](https://github.com/john-kurkowski/music) Python CLI to publish my
-    music (100+ hours error-prone clicks saved).
+{
+
+<ul className='list-disc ml-4'>
+  <li>
+    Prototyped and adopted tooling, component libraries, test coverage, and code
+    review guidelines, for clients such as WhoCo and Media Arts Lab (Apple),
+    using React, Ember.js, and Python.
+  </li>
+  <li>
+    Maintained OSS libraries:
+    <ul className='list-disc ml-6'>
+      <li>
+        <a className='link' href='https://github.com/john-kurkowski/tldextract'>
+          tldextract
+        </a>{' '}
+        Python library to parse URLs (35k+ dependents).
+      </li>
+      <li>
+        <a className='link' href='https://github.com/john-kurkowski/music'>
+          music
+        </a>{' '}
+        Python CLI to publish my music (100+ hours error-prone clicks saved).
+      </li>
+    </ul>
+  </li>
+</ul>
+}
 
 </Experience>
 
@@ -77,16 +100,29 @@ OR' position='Senior Software Developer'
 
 <Time begin={new Date('2013-04-15')} end={new Date('2020-02-15')} slot='time' />
 
-- Led UX team tech, architecting Ember.js SPAs to triage and hunt advanced
-  security threats.
-- Drove adoption of cross-team component library and microservice
-  Swagger/OpenAPI spec, coordinating Node.js, Python, Scala, and Elasticsearch
-  backends, in AWS.
-- Increased deploys from 1x/month to 10x/day, championing efficiency and team
-  feedback loop.
-- Grew team from 10 customers to 1k+, from 2 developers to 20.
-- Cultivated quality culture: oversaw peer code review, checklists, and
-  automated tests.
+{
+
+<ul className='list-disc ml-4'>
+  <li>
+    Led UX team tech, architecting Ember.js SPAs to triage and hunt advanced
+    security threats.
+  </li>
+  <li>
+    Drove adoption of cross-team component library and microservice
+    Swagger/OpenAPI spec, coordinating Node.js, Python, Scala, and Elasticsearch
+    backends, in AWS.
+  </li>
+  <li>
+    Increased deploys from 1x/month to 10x/day, championing efficiency and team
+    feedback loop.
+  </li>
+  <li>Grew team from 10 customers to 1k+, from 2 developers to 20.</li>
+  <li>
+    Cultivated quality culture: oversaw peer code review, checklists, and
+    automated tests.
+  </li>
+</ul>
+}
 
 </Experience>
 
@@ -97,14 +133,28 @@ position='Senior Software Developer'
 
 <Time begin={new Date('2010-11-15')} end={new Date('2013-04-15')} slot='time' />
 
-- Developed a Scala platform and 3rd party JavaScript for 30k/hr realtime,
-  personalized article recommendations, embedded in top 200 U.S. publisher
-  sites, such as TechCrunch.
-- Ingested 10k/hr live tweets for interest analytics visualizations, showcasing
-  our tech during sales.
-- Built browser extension for staff to annotate 100M node HBase, neo4j ontology.
-- Organized monthly 15-person Scala meetups, fostering local dev community and
-  recruitment.
+{
+
+<ul className='list-disc ml-4'>
+  <li>
+    Developed a Scala platform and 3rd party JavaScript for 30k/hr realtime,
+    personalized article recommendations, embedded in top 200 U.S. publisher
+    sites, such as TechCrunch.
+  </li>
+  <li>
+    Ingested 10k/hr live tweets for interest analytics visualizations,
+    showcasing our tech during sales.
+  </li>
+  <li>
+    Built browser extension for staff to annotate 100M node HBase, neo4j
+    ontology.
+  </li>
+  <li>
+    Organized monthly 15-person Scala meetups, fostering local dev community and
+    recruitment.
+  </li>
+</ul>
+}
 
 </Experience>
 
@@ -115,16 +165,31 @@ position='Software Developer'
 
 <Time begin={new Date('2008-09-15')} end={new Date('2010-08-15')} slot='time' />
 
-- Enhanced Java, MySQL, PostgreSQL audience analytics web app reaching 2M+
-  monthly users.
-- Reported churn risks to CEO in daily Hadoop dashboard, retaining 100s of
-  critical customers.
-- Spearheaded modern dev practices: prefix search, Python/Django tooling, DVCS
-  workflows.
+{
+
+<ul className='list-disc ml-4'>
+  <li>
+    Enhanced Java, MySQL, PostgreSQL audience analytics web app reaching 2M+
+    monthly users.
+  </li>
+  <li>
+    Reported churn risks to CEO in daily Hadoop dashboard, retaining 100s of
+    critical customers.
+  </li>
+  <li>
+    Spearheaded modern dev practices: prefix search, Python/Django tooling, DVCS
+    workflows.
+  </li>
+</ul>
+}
 
 </Experience>
 
+<div class="post">
+
 ## Education
+
+</div>
 
 <Experience
   className='mt-4'
@@ -133,12 +198,16 @@ position='Software Developer'
   position='B.S. Computer Science, B.A. Linguistics'
 />
 
+<div class="post">
+
 ## Colophon
 
 This site is coded and written in [iTerm2] and [vim]. It is built around the
 framework [Astro]. The site’s preferred display font is the humanist [Open
 Sans]. The preferred body font is the modern serif [Lora]. The site is hosted on
 [Netlify]. [Its source is available on GitHub][GitHub source].
+
+</div>
 
 [Astro]: https://astro.build/
 [Corporate UX Maturity: Stages 1-4]:

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -3,8 +3,8 @@ layout: ../components/layouts/page.astro
 title: 'About Me'
 ---
 
+import Experiences from '../components/resume/experiences.astro'
 import Experience from '../components/resume/experience.astro'
-import Time from '../components/resume/time.astro'
 
 <div class="post">
 
@@ -56,134 +56,7 @@ following.
 
 </div>
 
-<Experience className='mt-4' company='Self' location='Remote, Portland, OR'
-position='Software Development Consultant'
-
->
-
-<Time begin={new Date('2020-07-15')} end='present' slot='time' />
-
-{
-
-<ul className='list-disc ml-4'>
-  <li>
-    Prototyped and adopted tooling, component libraries, test coverage, and code
-    review guidelines, for clients such as WhoCo and Media Arts Lab (Apple),
-    using React, Ember.js, and Python.
-  </li>
-  <li>
-    Maintained OSS libraries:
-    <ul className='list-disc ml-6'>
-      <li>
-        <a className='link' href='https://github.com/john-kurkowski/tldextract'>
-          tldextract
-        </a>{' '}
-        Python library to parse URLs (35k+ dependents).
-      </li>
-      <li>
-        <a className='link' href='https://github.com/john-kurkowski/music'>
-          music
-        </a>{' '}
-        Python CLI to publish my music (100+ hours error-prone clicks saved).
-      </li>
-    </ul>
-  </li>
-</ul>
-}
-
-</Experience>
-
-<Experience className='mt-8' company='CrowdStrike' location='Remote, Portland,
-OR' position='Senior Software Developer'
-
->
-
-<Time begin={new Date('2013-04-15')} end={new Date('2020-02-15')} slot='time' />
-
-{
-
-<ul className='list-disc ml-4'>
-  <li>
-    Led UX team tech, architecting Ember.js SPAs to triage and hunt advanced
-    security threats.
-  </li>
-  <li>
-    Drove adoption of cross-team component library and microservice
-    Swagger/OpenAPI spec, coordinating Node.js, Python, Scala, and Elasticsearch
-    backends, in AWS.
-  </li>
-  <li>
-    Increased deploys from 1x/month to 10x/day, championing efficiency and team
-    feedback loop.
-  </li>
-  <li>Grew team from 10 customers to 1k+, from 2 developers to 20.</li>
-  <li>
-    Cultivated quality culture: oversaw peer code review, checklists, and
-    automated tests.
-  </li>
-</ul>
-}
-
-</Experience>
-
-<Experience className='mt-8' company='Gravity' location='Santa Monica, CA'
-position='Senior Software Developer'
-
->
-
-<Time begin={new Date('2010-11-15')} end={new Date('2013-04-15')} slot='time' />
-
-{
-
-<ul className='list-disc ml-4'>
-  <li>
-    Developed a Scala platform and 3rd party JavaScript for 30k/hr realtime,
-    personalized article recommendations, embedded in top 200 U.S. publisher
-    sites, such as TechCrunch.
-  </li>
-  <li>
-    Ingested 10k/hr live tweets for interest analytics visualizations,
-    showcasing our tech during sales.
-  </li>
-  <li>
-    Built browser extension for staff to annotate 100M node HBase, neo4j
-    ontology.
-  </li>
-  <li>
-    Organized monthly 15-person Scala meetups, fostering local dev community and
-    recruitment.
-  </li>
-</ul>
-}
-
-</Experience>
-
-<Experience className='mt-8' company='Quantcast' location='San Francisco, CA'
-position='Software Developer'
-
->
-
-<Time begin={new Date('2008-09-15')} end={new Date('2010-08-15')} slot='time' />
-
-{
-
-<ul className='list-disc ml-4'>
-  <li>
-    Enhanced Java, MySQL, PostgreSQL audience analytics web app reaching 2M+
-    monthly users.
-  </li>
-  <li>
-    Reported churn risks to CEO in daily Hadoop dashboard, retaining 100s of
-    critical customers.
-  </li>
-  <li>
-    Spearheaded modern dev practices: prefix search, Python/Django tooling, DVCS
-    workflows.
-  </li>
-</ul>
-}
-
-</Experience>
+<Experiences />
 
 <div class="post">
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,7 +40,7 @@ import Layout from '../components/layouts/base.astro'
         momentum from showing, not telling.
       </p>
 
-      <p>
+      <p class='mt-4'>
         Just want a tune up? I debug any existing, legacy, or unfinished system.
         I tend to work in TypeScript and Python, and I love learning new tech.
       </p>


### PR DESCRIPTION
Previously, with global styles, the custom "Experience" section of the "About Me" page was riddled with inconsistencies with the upstream resume, in presentation and code. Applying typography styles piecemeal allows the "About Me" page to better stay in sync.

# Changes

* Remove global paragraph style
* Remove global style undo hack
* Extract custom "Experience" section from Markdown to own component
* Sync from upstream resume
* Wrap Markdown content that should have the old styles in `<div class="post">`

