### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'quarterly'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'quarterly'


### PR DESCRIPTION
### Motivation
- Add a minimal Dependabot config so repository dependencies and GitHub Actions are checked on a low-frequency cadence appropriate for a static portfolio site.

### Description
- Create `.github/dependabot.yml` with `version: 2` and update entries for `npm` and `github-actions` targeting the repo root (`directory: '/'`) on a `quarterly` schedule.

### Testing
- Ran `npm run check:fix` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe8fab97a4832f9365749d586327ac)