### PR TITLE
Split CI checks from Netlify previews

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -1,7 +1,28 @@
-on: [push]
+name: CI
+
+on: [push, pull_request]
 
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Test
+        run: npm test
+
+  visual-regression:
     runs-on: ubuntu-latest
     name: Lost Pixel
 
@@ -27,3 +48,32 @@ jobs:
         uses: lost-pixel/lost-pixel@v3.22.0
         env:
           LOST_PIXEL_API_KEY: ${{ secrets.LOST_PIXEL_API_KEY }}
+
+  deploy-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    name: Deploy production
+    needs: [test, visual-regression]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build app
+        run: npm run build
+
+      - name: Deploy to Netlify
+        run: >
+          npx --yes netlify-cli deploy --prod --dir=dist --site
+          "$NETLIFY_SITE_ID" --auth "$NETLIFY_AUTH_TOKEN"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -27,6 +27,7 @@ jobs:
         run: npm test
 
   visual-regression:
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     name: Lost Pixel
 

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ Source for [johnkurkowski.com](https://johnkurkowski.com).
 
     npm test
 
-Tests are run in CI and must pass prior to deployment.
+Tests are run in GitHub Actions and must pass before production deploys.
 
 [Lost Pixel](https://app.lost-pixel.com/) visual regression review is run during
-CI, but does not block deployment. If there are visual differences in your
-build, they require manual, asynchronous review. Before push, you can preview
-Lost Pixel's snapshots against your running local server in production mode.
+CI and must pass before production deploys. Netlify deploy previews run build
+only; production deploys are published by GitHub Actions after tests and visual
+regression pass. Before push, you can preview Lost Pixel's snapshots against
+your running local server in production mode.
 
     npm run build
-    npm run serve &
+    npm run preview &
     npx lost-pixel local

--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@ Source for [johnkurkowski.com](https://johnkurkowski.com).
 
     npm test
 
-Tests are run in GitHub Actions and must pass before production deploys.
+Tests are run in CI and must pass before production deploy, i.e. pushes to
+trunk. Branches deploy regardless of CI passing.
 
-[Lost Pixel](https://app.lost-pixel.com/) visual regression review is run during
-CI and must pass before production deploys. Netlify deploy previews run build
-only; production deploys are published by GitHub Actions after tests and visual
-regression pass. Before push, you can preview Lost Pixel's snapshots against
-your running local server in production mode.
+Before push, you can preview [Lost Pixel](https://app.lost-pixel.com/) VRT's
+snapshots against your running local server in production mode.
 
     npm run build
     npm run preview &

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
-  command = "npm test && npm run build"
+  command = "npm run build"
+  ignore = "[ \"$CONTEXT\" = \"production\" ]"
   publish = "dist/"


### PR DESCRIPTION
## Context

Previously, failing typechecks would prevent branch deploy previews. Failed production deploy reasons were primarily due to the test suite, and not visible from GitHub.

Move the primary checking responsibility to GitHub Actions.

## Changes

* Run tests and visual regression in GitHub Actions
* Leave Netlify deploy previews build-only
* For production, _publish_ in Netlify _after_ GitHub Actions pass